### PR TITLE
fix: commitizen bumps version in decli/__init_.py

### DIFF
--- a/decli/__init__.py
+++ b/decli/__init__.py
@@ -1,5 +1,5 @@
 from .application import cli
 
-__version__ = "0.5.2"
+__version__ = "0.6.0"
 
 __all__ = ("cli",)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,6 @@ version_type = "pep440"
 version_provider = "poetry"
 update_changelog_on_bump = true
 major_version_zero = true
+version_files = [
+    "decli/__init__.py:__version__",
+]


### PR DESCRIPTION
Hello

Looks like the last `cz bump` for the v0.6 release did not bump the `__version__` in the `decli/__init__.py` file.

A resolution is to add this file to the list of version files in the commitizen configuration.

See https://commitizen-tools.github.io/commitizen/bump/