### PR TITLE
fix: add missing build-system

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,7 @@ major_version_zero = true
 version_files = [
     "decli/__init__.py:__version__",
 ]
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This causes missing metadata for source builds (since `build-system` will default to `setuptools` which won't pickup the metadata from poetry)

```console
$ pip install --no-binary=:all: decli
Collecting decli
  Downloading decli-0.6.1.tar.gz (7.4 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Discarding https://files.pythonhosted.org/packages/2e/9c/b76485e6120795c8b632707bafb4a9a4a2b75584ca5277e3e175c5d02225/decli-0.6.1.tar.gz (from https://pypi.org/simple/decli/) (requires-python:>=3.7): Requested decli from https://files.pythonhosted.org/packages/2e/9c/b76485e6120795c8b632707bafb4a9a4a2b75584ca5277e3e175c5d02225/decli-0.6.1.tar.gz has inconsistent version: expected '0.6.1', but metadata has '0.0.0'
```
